### PR TITLE
Fix rockspec and include stdint.h to hash.c to fix compilation errors

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -4,6 +4,8 @@
 #include "luaT.h"
 #include "TH.h"
 
+#include <stdint.h>
+
 typedef uint32_t (*libhash_hashfunc32_t)(const void *data, size_t len, uint32_t seed);
 typedef uint64_t (*libhash_hashfunc64_t)(const void *data, size_t len, uint64_t seed);
 

--- a/rocks/hash-scm-1.rockspec
+++ b/rocks/hash-scm-1.rockspec
@@ -2,7 +2,7 @@ package = "hash"
 version = "scm-1"
 
 source = {
-   url = "git://github.com/torch/hash-ffi.git"
+   url = "git://github.com/torch/hash.git"
 }
 
 description = {


### PR DESCRIPTION
Fix compilations errors on both Ubuntu 12.04 with gcc 4.6.3 and Ubuntu 14.04 with gcc 4.8.2.
Small fix on the url of the rockspec.
