### PR TITLE
use explicit string/number type checks

### DIFF
--- a/libhash.c
+++ b/libhash.c
@@ -24,12 +24,12 @@ IMPLEMENT_THTENSOR_HASH(Double, double);
 
 static void libhash_updatehash(lua_State *L, LHHash *state, int idx)
 {
-  if(lua_isstring(L, idx)) {
+  if(lua_type(L, idx) == LUA_TSTRING) {
     size_t len = 0;
     const char *str = lua_tolstring(L, idx, &len);
     LHHash_update(state, str, len);
   }
-  else if(lua_isnumber(L, idx)) {
+  else if(lua_type(L, idx) == LUA_TNUMBER) {
     lua_Number num = lua_tonumber(L, idx);
     LHHash_update(state, &num, sizeof(lua_Number));
   }


### PR DESCRIPTION
To make sure numbers are not converted to a string before hashing (since `lua_isstring` returns 1 if the value is a string or a number). 

Example:

``` Lua
require "torch"
hash = require "hash"

t = torch.rand(3)

h = hash.XXH64(); h:reset(0)
t:apply(function(v) h:update(v) end)

assert(hash.hash(t) == h:digest()) -- fails!!
```
